### PR TITLE
Creating simple article archive by month and year

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -5,6 +5,9 @@ class ArticlesController < ApplicationController
   def index
     if params[:search]
       @articles = Article.search(params[:search]).order(created_at: :desc)
+    elsif params[:month]
+      date = Date.parse("1 #{params[:month]}")
+      @articles = Article.where(:created_at => date..date.end_of_month)
     else
       @articles = Article.order(created_at: :desc)
     end

--- a/app/views/articles/edit.html.erb
+++ b/app/views/articles/edit.html.erb
@@ -10,3 +10,5 @@
     <%= render 'layouts/sidebar' %>
   </div>
 </div>
+
+

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -16,10 +16,9 @@
    <div class="row">
       <div class="col-lg-6">
         <ul class="list-unstyled">
-          <li><a href="#">October</a></li>
-          <li><a href="#">September</a></li>
-          <li><a href="#">August</a></li>
-          <li><a href="#">July</a></li>
+          <% Article.order(created_at: :desc).group_by { |article| article.created_at.strftime("%B %Y") }.take(10).each do |month, article| %>
+            <li><%= link_to month, root_path(:month => month) %></li>
+          <% end %>
         </ul>
       </div>
     </div>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -57,5 +57,4 @@ ActiveRecord::Schema.define(version: 20161121131057) do
     t.string   "user_name"
     t.boolean  "admin",         default: false
   end
-
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,11 +6,21 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
-User.delete_all
-
 User.create(
   email: "admin@admin.com",
   password: "admin1",
   password_confirmation: "admin1",
   user_name: "admin",
   admin: true)
+
+Article.create(
+  title: "Testing Archive functionality 1",
+  text: "Testing Archive functionality 1",
+  created_at: "2014-01-01 10:00:00",
+  user_id: "1")
+
+Article.create(
+  title: "Testing Archive functionality 2",
+  text: "Testing Archive functionality 2",
+  created_at: "2015-01-01 10:00:00",
+  user_id: "1")


### PR DESCRIPTION
Added a simple archive to the side bar:
- Now users can view all articles posted in specific month/year
- Archive is limited to show to the last 10 months
To do:
- Full archive page with all months/years

![archive](https://cloud.githubusercontent.com/assets/20456492/20561154/b83fcb9a-b185-11e6-9ed6-9b448b3635fc.PNG)
